### PR TITLE
PCQ-700 - Added explicity Java11 source compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,11 @@ apply plugin: 'com.github.lkishalmi.gatling'
 group 'uk.gov.hmcts.reform'
 version = '1.0'
 
+allprojects {
+    sourceCompatibility = '11'
+    targetCompatibility = '11'
+}
+
 jar {
     manifest {
         attributes 'Main-Class': 'io.gatling.app.Gatling'


### PR DESCRIPTION
### JIRA link (if applicable) ###
PCQ-700


### Change description ###
Added Java11 source compatibility explicitly in the build.gradle. From 26th September, the Jenkins pipeline expects this to to there otherwise the pipeline complains that project is not Java11 compatible.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
